### PR TITLE
release: @react-native-oh-tpl/react-native-gifted-charts@1.4.16-0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-oh-tpl/react-native-gifted-charts",
-  "version": "1.4.16-0.0.1",
+  "version": "1.4.16-0.0.2",
   "description": "The most complete library for Bar, Line, Area, Pie, Donut, Stacked Bar and Population Pyramid charts in React Native. Allows 2D, 3D, gradient, animations and live data updates.",
   "main": "src/index.tsx",
   "harmony": {
@@ -28,8 +28,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "gifted-charts-core": "^0.1.13",
-    "react-native-gifted-charts":"^1.4.16"
+    "gifted-charts-core": "0.1.13",
+    "react-native-gifted-charts":"1.4.16"
   },
   "devDependencies": {
     "@babel/core": "^7.22.5",


### PR DESCRIPTION
修复依赖项未锁定为指定版本的问题